### PR TITLE
Add readings history feature

### DIFF
--- a/common/schema/dev.zwander.common.database.Database/2.json
+++ b/common/schema/dev.zwander.common.database.Database/2.json
@@ -1,0 +1,128 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "",
+    "entities": [
+      {
+        "tableName": "HistoricalSnapshot",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timeMillis` INTEGER NOT NULL, `cellData` TEXT, `clientData` TEXT, `mainData` TEXT, `simData` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "timeMillis",
+            "columnName": "timeMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cellData",
+            "columnName": "cellData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "clientData",
+            "columnName": "clientData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mainData",
+            "columnName": "mainData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "simData",
+            "columnName": "simData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        }
+      },
+      {
+        "tableName": "SavedReading",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `location` TEXT, `notes` TEXT, `timeMillis` INTEGER NOT NULL, `cellData` TEXT, `clientData` TEXT, `mainData` TEXT, `simData` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timeMillis",
+            "columnName": "timeMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cellData",
+            "columnName": "cellData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "clientData",
+            "columnName": "clientData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mainData",
+            "columnName": "mainData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "simData",
+            "columnName": "simData",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        }
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '')"
+    ]
+  }
+}

--- a/common/src/commonMain/kotlin/dev/zwander/common/components/SaveReadingDialog.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/components/SaveReadingDialog.kt
@@ -27,6 +27,7 @@ fun SaveReadingDialog(
     val scope = rememberCoroutineScope()
 
     InWindowAlertDialog(
+        showing = true,
         onDismissRequest = onDismiss,
         title = {
             Text(stringResource(MR.strings.save_reading))

--- a/common/src/commonMain/kotlin/dev/zwander/common/components/SaveReadingDialog.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/components/SaveReadingDialog.kt
@@ -1,0 +1,125 @@
+package dev.zwander.common.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.icerock.moko.resources.compose.stringResource
+import dev.zwander.common.data.SavedReading
+import dev.zwander.common.database.getRoomDatabase
+import dev.zwander.common.model.MainModel
+import dev.zwander.compose.alertdialog.InWindowAlertDialog
+import dev.zwander.resources.common.MR
+import kotlinx.coroutines.launch
+
+@Composable
+fun SaveReadingDialog(
+    onDismiss: () -> Unit,
+    onSaved: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var name by remember { mutableStateOf("") }
+    var location by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var isSaving by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    InWindowAlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(MR.strings.save_reading))
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(MR.strings.reading_name)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                
+                OutlinedTextField(
+                    value = location,
+                    onValueChange = { location = it },
+                    label = { Text(stringResource(MR.strings.location_optional)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                
+                OutlinedTextField(
+                    value = notes,
+                    onValueChange = { notes = it },
+                    label = { Text(stringResource(MR.strings.notes_optional)) },
+                    minLines = 2,
+                    maxLines = 4,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        buttons = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                }
+                
+                TextButton(
+                    onClick = onDismiss,
+                    enabled = !isSaving,
+                ) {
+                    Text(stringResource(MR.strings.cancel))
+                }
+                
+                Spacer(modifier = Modifier.width(8.dp))
+                
+                TextButton(
+                    onClick = {
+                        if (name.isNotBlank()) {
+                            isSaving = true
+                            scope.launch {
+                                try {
+                                    val database = getRoomDatabase()
+                                    val reading = SavedReading(
+                                        name = name.trim(),
+                                        location = location.trim().takeIf { it.isNotBlank() },
+                                        notes = notes.trim().takeIf { it.isNotBlank() },
+                                        timeMillis = System.currentTimeMillis(),
+                                        mainData = MainModel.currentMainData.value,
+                                        cellData = MainModel.currentCellData.value,
+                                        clientData = MainModel.currentClientData.value,
+                                        simData = MainModel.currentSimData.value,
+                                    )
+                                    database.getSavedReadingDao().insert(reading)
+                                    onSaved()
+                                    onDismiss()
+                                } catch (e: Exception) {
+                                    e.printStackTrace()
+                                } finally {
+                                    isSaving = false
+                                }
+                            }
+                        }
+                    },
+                    enabled = name.isNotBlank() && !isSaving,
+                ) {
+                    Text(stringResource(MR.strings.save))
+                }
+            }
+        },
+        modifier = modifier,
+    )
+}

--- a/common/src/commonMain/kotlin/dev/zwander/common/data/Page.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/data/Page.kt
@@ -124,7 +124,7 @@ sealed class Page(
     data object ReadingsHistory : Page(
         titleRes = MR.strings.readings_history,
         key = READINGS_HISTORY_PAGE_KEY,
-        icon = { rememberVectorPainter(Icons.Default.DateRange) },
+        icon = { rememberVectorPainter(Icons.Default.List) },
         refreshAction = null,
         needsRefresh = null,
         render = { ReadingsHistoryPage(it) },

--- a/common/src/commonMain/kotlin/dev/zwander/common/data/Page.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/data/Page.kt
@@ -30,6 +30,7 @@ sealed class Page(
         const val WIFI_PAGE_KEY = "wifi_page"
         const val SETTINGS_PAGE_KEY = "settings_page"
         const val FUZZER_PAGE_KEY = "fuzzer_page"
+        const val READINGS_HISTORY_PAGE_KEY = "readings_history_page"
 
         fun pageFromKey(key: String): Page {
             return when (key) {
@@ -39,6 +40,7 @@ sealed class Page(
                 WIFI_PAGE_KEY -> WifiConfig
                 SETTINGS_PAGE_KEY -> SettingsPage
                 FUZZER_PAGE_KEY -> FuzzerPage
+                READINGS_HISTORY_PAGE_KEY -> ReadingsHistory
                 else -> throw IllegalArgumentException("Unknown key $key")
             }
         }
@@ -117,5 +119,14 @@ sealed class Page(
         refreshAction = null,
         needsRefresh = null,
         render = { FuzzerPage(it) },
+    )
+    
+    data object ReadingsHistory : Page(
+        titleRes = MR.strings.readings_history,
+        key = READINGS_HISTORY_PAGE_KEY,
+        icon = { rememberVectorPainter(Icons.Default.History) },
+        refreshAction = null,
+        needsRefresh = null,
+        render = { ReadingsHistoryPage(it) },
     )
 }

--- a/common/src/commonMain/kotlin/dev/zwander/common/data/Page.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/data/Page.kt
@@ -124,7 +124,7 @@ sealed class Page(
     data object ReadingsHistory : Page(
         titleRes = MR.strings.readings_history,
         key = READINGS_HISTORY_PAGE_KEY,
-        icon = { rememberVectorPainter(Icons.Default.History) },
+        icon = { rememberVectorPainter(Icons.Default.DateRange) },
         refreshAction = null,
         needsRefresh = null,
         render = { ReadingsHistoryPage(it) },

--- a/common/src/commonMain/kotlin/dev/zwander/common/data/SavedReading.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/data/SavedReading.kt
@@ -1,0 +1,32 @@
+package dev.zwander.common.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
+import dev.zwander.common.database.CellDataRootConverter
+import dev.zwander.common.database.ClientDeviceDataConverter
+import dev.zwander.common.database.MainDataConverter
+import dev.zwander.common.database.SimDataRootConverter
+import dev.zwander.common.model.adapters.CellDataRoot
+import dev.zwander.common.model.adapters.ClientDeviceData
+import dev.zwander.common.model.adapters.MainData
+import dev.zwander.common.model.adapters.SimDataRoot
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Entity
+data class SavedReading(
+    val name: String,
+    val location: String? = null,
+    val notes: String? = null,
+    val timeMillis: Long,
+    @field:TypeConverters(CellDataRootConverter::class)
+    val cellData: CellDataRoot? = null,
+    @field:TypeConverters(ClientDeviceDataConverter::class)
+    val clientData: ClientDeviceData? = null,
+    @field:TypeConverters(MainDataConverter::class)
+    val mainData: MainData? = null,
+    @field:TypeConverters(SimDataRootConverter::class)
+    val simData: SimDataRoot? = null,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+)

--- a/common/src/commonMain/kotlin/dev/zwander/common/database/Database.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/database/Database.kt
@@ -73,7 +73,7 @@ expect fun getDatabaseBuilder(): RoomDatabase.Builder<dev.zwander.common.databas
 fun getRoomDatabase(): dev.zwander.common.database.Database {
     return getDatabaseBuilder()
         .fallbackToDestructiveMigrationOnDowngrade(false)
-        .fallbackToDestructiveMigration()
+        .fallbackToDestructiveMigration(dropAllTables = true)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
         .build()

--- a/common/src/commonMain/kotlin/dev/zwander/common/pages/MainPage.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/pages/MainPage.kt
@@ -4,8 +4,13 @@ package dev.zwander.common.pages
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -29,7 +34,9 @@ import dev.zwander.common.components.DeviceDataLayout
 import dev.zwander.common.components.InfoRow
 import dev.zwander.common.components.MainDataLayout
 import dev.zwander.common.components.PageGrid
+import dev.zwander.common.components.SaveReadingDialog
 import dev.zwander.common.components.SnapshotChart
+import dev.zwander.common.data.Page
 import dev.zwander.common.data.generateInfoList
 import dev.zwander.common.data.set
 import dev.zwander.common.model.GlobalModel
@@ -60,6 +67,8 @@ fun MainPage(
     val httpClient by GlobalModel.httpClient.collectAsState()
     val showSnapshots by SettingsModel.recordSnapshots.collectAsState()
     val scope = rememberCoroutineScope()
+    var showSaveDialog by remember { mutableStateOf(false) }
+    var navigateToHistory by remember { mutableStateOf(false) }
 
     val items = remember {
         listOf(
@@ -186,32 +195,59 @@ fun MainPage(
                 it.render(Modifier.fillMaxWidth())
             },
             bottomBarContents = {
-                Button(
-                    onClick = {
-                        scope.launch {
-                            UserModel.logOut()
-                        }
-                    },
-                    modifier = Modifier.weight(1f),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(MR.strings.log_out),
-                    )
-                }
+                    // Save and History buttons
+                    IconButton(
+                        onClick = { showSaveDialog = true },
+                        enabled = MainModel.currentMainData.value != null,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Save,
+                            contentDescription = stringResource(MR.strings.save_reading),
+                        )
+                    }
+                    
+                    IconButton(
+                        onClick = { navigateToHistory = true },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.History,
+                            contentDescription = stringResource(MR.strings.readings_history),
+                        )
+                    }
+                    
+                    Spacer(modifier = Modifier.weight(1f))
+                    
+                    // Existing buttons
+                    Button(
+                        onClick = {
+                            scope.launch {
+                                UserModel.logOut()
+                            }
+                        },
+                    ) {
+                        Text(
+                            text = stringResource(MR.strings.log_out),
+                        )
+                    }
 
-                Button(
-                    onClick = {
-                        showingRebootConfirmation = true
-                    },
-                    modifier = Modifier.weight(1f),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.contentColorFor(MaterialTheme.colorScheme.error),
-                    ),
-                ) {
-                    Text(
-                        text = stringResource(MR.strings.reboot),
-                    )
+                    Button(
+                        onClick = {
+                            showingRebootConfirmation = true
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.contentColorFor(MaterialTheme.colorScheme.error),
+                        ),
+                    ) {
+                        Text(
+                            text = stringResource(MR.strings.reboot),
+                        )
+                    }
                 }
             },
             itemIsSelectable = {
@@ -292,4 +328,19 @@ fun MainPage(
             }
         },
     )
+    
+    if (showSaveDialog) {
+        SaveReadingDialog(
+            onDismiss = { showSaveDialog = false },
+            onSaved = { 
+                // Optionally show a success message or navigate to history
+            },
+        )
+    }
+    
+    if (navigateToHistory) {
+        // Navigate to history page - will implement this after creating the page
+        navigateToHistory = false
+        GlobalModel.currentPage.value = Page.ReadingsHistory
+    }
 }

--- a/common/src/commonMain/kotlin/dev/zwander/common/pages/MainPage.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/pages/MainPage.kt
@@ -5,8 +5,8 @@ package dev.zwander.common.pages
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -206,7 +206,7 @@ fun MainPage(
                         enabled = MainModel.currentMainData.value != null,
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Save,
+                            imageVector = Icons.Default.Bookmark,
                             contentDescription = stringResource(MR.strings.save_reading),
                         )
                     }
@@ -215,7 +215,7 @@ fun MainPage(
                         onClick = { navigateToHistory = true },
                     ) {
                         Icon(
-                            imageVector = Icons.Default.History,
+                            imageVector = Icons.Default.DateRange,
                             contentDescription = stringResource(MR.strings.readings_history),
                         )
                     }

--- a/common/src/commonMain/kotlin/dev/zwander/common/pages/MainPage.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/pages/MainPage.kt
@@ -5,8 +5,8 @@ package dev.zwander.common.pages
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Bookmark
-import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -206,7 +206,7 @@ fun MainPage(
                         enabled = MainModel.currentMainData.value != null,
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Bookmark,
+                            imageVector = Icons.Default.Add,
                             contentDescription = stringResource(MR.strings.save_reading),
                         )
                     }
@@ -215,7 +215,7 @@ fun MainPage(
                         onClick = { navigateToHistory = true },
                     ) {
                         Icon(
-                            imageVector = Icons.Default.DateRange,
+                            imageVector = Icons.Default.List,
                             contentDescription = stringResource(MR.strings.readings_history),
                         )
                     }

--- a/common/src/commonMain/kotlin/dev/zwander/common/pages/ReadingsHistoryPage.kt
+++ b/common/src/commonMain/kotlin/dev/zwander/common/pages/ReadingsHistoryPage.kt
@@ -1,0 +1,405 @@
+package dev.zwander.common.pages
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.icerock.moko.resources.compose.stringResource
+import dev.zwander.common.components.HybridElevatedCard
+import dev.zwander.common.components.InfoRow
+import dev.zwander.common.data.SavedReading
+import dev.zwander.common.database.getRoomDatabase
+import dev.zwander.compose.alertdialog.InWindowAlertDialog
+import dev.zwander.resources.common.MR
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+fun ReadingsHistoryPage(
+    modifier: Modifier = Modifier,
+) {
+    val database = remember { getRoomDatabase() }
+    val savedReadingsFlow = remember { database.getSavedReadingDao().getAll() }
+    val savedReadings by savedReadingsFlow.collectAsState(initial = emptyList())
+    
+    var selectedReading by remember { mutableStateOf<SavedReading?>(null) }
+    var readingToDelete by remember { mutableStateOf<SavedReading?>(null) }
+    val scope = rememberCoroutineScope()
+    
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            text = stringResource(MR.strings.readings_history),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
+        
+        if (savedReadings.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(MR.strings.no_saved_readings),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(savedReadings) { reading ->
+                    SavedReadingCard(
+                        reading = reading,
+                        onViewDetails = { selectedReading = reading },
+                        onDelete = { readingToDelete = reading },
+                    )
+                }
+            }
+        }
+    }
+    
+    // Details Dialog
+    selectedReading?.let { reading ->
+        ReadingDetailsDialog(
+            reading = reading,
+            onDismiss = { selectedReading = null },
+        )
+    }
+    
+    // Delete Confirmation Dialog
+    readingToDelete?.let { reading ->
+        InWindowAlertDialog(
+            onDismissRequest = { readingToDelete = null },
+            title = {
+                Text(stringResource(MR.strings.delete_reading))
+            },
+            text = {
+                Text(stringResource(MR.strings.delete_reading_confirmation))
+            },
+            buttons = {
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    TextButton(
+                        onClick = { readingToDelete = null },
+                    ) {
+                        Text(stringResource(MR.strings.cancel))
+                    }
+                    
+                    Spacer(modifier = Modifier.width(8.dp))
+                    
+                    TextButton(
+                        onClick = {
+                            scope.launch {
+                                database.getSavedReadingDao().delete(reading.id)
+                                readingToDelete = null
+                            }
+                        },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) {
+                        Text(stringResource(MR.strings.delete))
+                    }
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SavedReadingCard(
+    reading: SavedReading,
+    onViewDetails: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    HybridElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(
+                        text = reading.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    
+                    reading.location?.let { location ->
+                        Text(
+                            text = location,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    
+                    val instant = Instant.fromEpochMilliseconds(reading.timeMillis)
+                    val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+                    Text(
+                        text = "${localDateTime.date} ${localDateTime.hour.toString().padStart(2, '0')}:${localDateTime.minute.toString().padStart(2, '0')}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                
+                Row {
+                    IconButton(onClick = onDelete) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = stringResource(MR.strings.delete),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+            
+            // Display key signal metrics
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                reading.mainData?.signal?.fourG?.let { lte ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = "LTE",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                        Text(
+                            text = "${lte.rsrp ?: "--"} dBm",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = "RSRP",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                
+                reading.mainData?.signal?.fiveG?.let { fiveG ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = "5G",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                        Text(
+                            text = "${fiveG.rsrp ?: "--"} dBm",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = "RSRP",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                
+                reading.mainData?.signal?.fourG?.let { lte ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = "LTE",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                        Text(
+                            text = "${lte.sinr ?: "--"} dB",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = "SINR",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                
+                reading.mainData?.signal?.fiveG?.let { fiveG ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = "5G",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                        Text(
+                            text = "${fiveG.sinr ?: "--"} dB",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = "SINR",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            Button(
+                onClick = onViewDetails,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(MR.strings.view_details))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadingDetailsDialog(
+    reading: SavedReading,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    InWindowAlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(reading.name)
+        },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 400.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                item {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        reading.location?.let { location ->
+                            InfoRow(
+                                label = stringResource(MR.strings.location_optional).replace(" (optional)", ""),
+                                value = location,
+                            )
+                        }
+                        
+                        reading.notes?.let { notes ->
+                            InfoRow(
+                                label = stringResource(MR.strings.notes_optional).replace(" (optional)", ""),
+                                value = notes,
+                            )
+                        }
+                        
+                        val instant = Instant.fromEpochMilliseconds(reading.timeMillis)
+                        val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+                        InfoRow(
+                            label = "Time",
+                            value = "${localDateTime.date} ${localDateTime.hour.toString().padStart(2, '0')}:${localDateTime.minute.toString().padStart(2, '0')}",
+                        )
+                    }
+                }
+                
+                // LTE Data
+                reading.mainData?.signal?.fourG?.let { lte ->
+                    item {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = stringResource(MR.strings.lte),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            lte.bands?.let { InfoRow(label = stringResource(MR.strings.bands), value = it.joinToString(", ")) }
+                            lte.rsrp?.let { InfoRow(label = stringResource(MR.strings.rsrp), value = "$it dBm") }
+                            lte.rsrq?.let { InfoRow(label = stringResource(MR.strings.rsrq), value = "$it dB") }
+                            lte.rssi?.let { InfoRow(label = stringResource(MR.strings.rssi), value = "$it dBm") }
+                            lte.sinr?.let { InfoRow(label = stringResource(MR.strings.sinr), value = "$it dB") }
+                            lte.cid?.let { InfoRow(label = stringResource(MR.strings.cid), value = it.toString()) }
+                            lte.nbid?.let { InfoRow(label = stringResource(MR.strings.enbid), value = it.toString()) }
+                        }
+                    }
+                }
+                
+                // 5G Data
+                reading.mainData?.signal?.fiveG?.let { fiveG ->
+                    item {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = stringResource(MR.strings.five_g),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            fiveG.bands?.let { InfoRow(label = stringResource(MR.strings.bands), value = it.joinToString(", ")) }
+                            fiveG.rsrp?.let { InfoRow(label = stringResource(MR.strings.rsrp), value = "$it dBm") }
+                            fiveG.rsrq?.let { InfoRow(label = stringResource(MR.strings.rsrq), value = "$it dB") }
+                            fiveG.rssi?.let { InfoRow(label = stringResource(MR.strings.rssi), value = "$it dBm") }
+                            fiveG.sinr?.let { InfoRow(label = stringResource(MR.strings.sinr), value = "$it dB") }
+                            fiveG.cid?.let { InfoRow(label = stringResource(MR.strings.cid), value = it.toString()) }
+                            fiveG.nbid?.let { InfoRow(label = stringResource(MR.strings.gnbid), value = it.toString()) }
+                        }
+                    }
+                }
+                
+                // Device Data
+                reading.mainData?.device?.let { device ->
+                    item {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = stringResource(MR.strings.device),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            device.friendlyName?.let { InfoRow(label = "Name", value = it) }
+                            device.model?.let { InfoRow(label = "Model", value = it) }
+                            device.softwareVersion?.let { InfoRow(label = "Software", value = it) }
+                        }
+                    }
+                }
+            }
+        },
+        buttons = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(MR.strings.ok))
+            }
+        },
+        modifier = modifier,
+    )
+}

--- a/common/src/commonMain/moko-resources/base/strings.xml
+++ b/common/src/commonMain/moko-resources/base/strings.xml
@@ -243,4 +243,17 @@
     <string name="cqi_index_helper_text">CQI stands for Channel Quality Indicator. The CQI Table Index represents the index of the table found in 3GPP TS 136.213 section 7.2.3.</string>
     <string name="rscp_helper_text">RSCP stands for Received Signal Code Power and is used as a signal strength indicator.</string>
     <string name="status_helper_text">Denotes the current connection status of the gateway to this cell.</string>
+    
+    <string name="save_reading">Save Reading</string>
+    <string name="reading_name">Name</string>
+    <string name="location_optional">Location (optional)</string>
+    <string name="notes_optional">Notes (optional)</string>
+    <string name="save">Save</string>
+    <string name="cancel">Cancel</string>
+    <string name="readings_history">Readings History</string>
+    <string name="no_saved_readings">No saved readings yet</string>
+    <string name="delete_reading">Delete Reading</string>
+    <string name="delete_reading_confirmation">Are you sure you want to delete this reading?</string>
+    <string name="view_details">View Details</string>
+    <string name="delete">Delete</string>
 </resources>


### PR DESCRIPTION
## Summary
- Implemented a save and history feature for router readings
- Users can now track router performance across different locations
- Added ability to tag readings with custom names and notes

## Changes
- **New SavedReading entity**: Stores router readings with user-defined name, location, and notes
- **SaveReadingDialog component**: UI for capturing user input when saving readings
- **ReadingsHistoryPage**: New page to view, manage, and delete saved readings
- **Updated MainPage**: Added save and history navigation buttons
- **Database migration**: Incremented to version 2 with new SavedReading table
- **String resources**: Added new strings for the feature UI

## Test Plan
- [ ] Test saving a reading with name only
- [ ] Test saving a reading with name, location, and notes
- [ ] Verify saved readings appear in history page
- [ ] Test viewing detailed information for a saved reading
- [ ] Test deleting a saved reading
- [ ] Verify empty state displays when no readings are saved
- [ ] Test navigation between main page and history page
- [ ] Verify save button is disabled when no data is available

🤖 Generated with [Claude Code](https://claude.ai/code)